### PR TITLE
Change avatar to image

### DIFF
--- a/current/react-apollo-blog/src/components/About.js
+++ b/current/react-apollo-blog/src/components/About.js
@@ -13,7 +13,7 @@ const About = ({ data: { loading, error, authors } }) => {
               <img
                 className='About-img'
                 alt={author.name}
-                src={`https://media.graphcms.com/resize=w:100,h:100,fit:crop/${author.avatar.handle}`}
+                src={`https://media.graphcms.com/resize=w:100,h:100,fit:crop/${author.image.handle}`}
               />
               <h1>Hello! My name is {author.name}</h1>
             </div>
@@ -32,7 +32,7 @@ export const authors = gql`
       id
       name
       bibliography
-      avatar {
+      image {
         handle
       }
     }

--- a/current/react-apollo-blog/src/index.js
+++ b/current/react-apollo-blog/src/index.js
@@ -12,7 +12,10 @@ import './index.css'
 import registerServiceWorker from './registerServiceWorker'
 
 // Replace this with your project's endpoint
-const GRAPHCMS_API = 'https://api-useast.graphcms.com/v1/cjiacyow100ob01eqwnghonw2/master'
+// this one works
+// const GRAPHCMS_API = 'https://api-useast.graphcms.com/v1/cjiacyow100ob01eqwnghonw2/master'
+// mine does not work.
+const GRAPHCMS_API = 'https://api-uswest.graphcms.com/v1/cjn652yks0ecs01gh893ud2ta/master'
 
 const client = new ApolloClient({
   link: new HttpLink({ uri: GRAPHCMS_API }),

--- a/current/react-apollo-blog/src/index.js
+++ b/current/react-apollo-blog/src/index.js
@@ -12,10 +12,7 @@ import './index.css'
 import registerServiceWorker from './registerServiceWorker'
 
 // Replace this with your project's endpoint
-// this one works
-// const GRAPHCMS_API = 'https://api-useast.graphcms.com/v1/cjiacyow100ob01eqwnghonw2/master'
-// mine does not work.
-const GRAPHCMS_API = 'https://api-uswest.graphcms.com/v1/cjn652yks0ecs01gh893ud2ta/master'
+const GRAPHCMS_API = 'https://api-useast.graphcms.com/v1/cjiacyow100ob01eqwnghonw2/master'
 
 const client = new ApolloClient({
   link: new HttpLink({ uri: GRAPHCMS_API }),


### PR DESCRIPTION
Changes author.avatar reference to author.image reference to match up with the GraphCMS getting started project.
NB: the Author schema will need to change 'avatar' to 'image' in the database referenced `const GRAPHCMS_API = 'https://api-useast.graphcms.com/v1/cjiacyow100ob01eqwnghonw2/master'`