### PR TITLE
chore (with-gatsby): 🐛 fix invalid gql field

### DIFF
--- a/with-gatsby/graphcms-fragments/Product.graphql
+++ b/with-gatsby/graphcms-fragments/Product.graphql
@@ -34,5 +34,4 @@ fragment Product on Product {
       text
     }
   }
-  content2
 }


### PR DESCRIPTION
I noticed `content2` in `Product` fragment is invalid, which was causing builds to fail in gatsby-cloud 

<img width="860" alt="image" src="https://user-images.githubusercontent.com/23198481/152003353-4cb0e6bf-f5f4-4285-8b59-e2f6956e538d.png">
